### PR TITLE
ntcmd - Check the result of QuerySystemInformation instead of crashing

### DIFF
--- a/base/ntcmd/src/sysinfo.c
+++ b/base/ntcmd/src/sysinfo.c
@@ -136,6 +136,12 @@ NTSTATUS RtlCliListDrivers(VOID)
     //
     Status = NtQuerySystemInformation(SystemModuleInformation,
 				      ModuleInfo, Size, NULL);
+
+    if (!NT_SUCCESS(Status)) {
+        RtlCliDisplayString("**** FAILED TO QUERY SYSTEM INFORMATION");
+        return Status;
+    }
+
     //
     // Display Header
     //


### PR DESCRIPTION
Hi

This is a nice fun project, congrats!
I tried it a bit and noticed the lm command crashed. Less nice... So here is a basic fix (but it would be much nicer to implement QuerySystemInformation(SystemModuleInformation), obviously)