### PR TITLE
Implement QuerySystemInformation(SystemProcessorInformation)

### DIFF
--- a/private/ntos/inc/ke.h
+++ b/private/ntos/inc/ke.h
@@ -787,6 +787,10 @@ static inline NTSTATUS KeEnableIoPort(IN USHORT PortNum,
 /* init.c */
 extern ULONG KeX86TscFreq;
 extern ULONG KeProcessorCount;
+extern ULONG KeProcessorArchitecture;
+extern ULONG KeProcessorLevel;
+extern ULONG KeProcessorRevision;
+extern ULONG KeFeatureBits;
 
 /* irq.c */
 NTSTATUS KeCreateIrqHandlerEx(IN PIRQ_HANDLER IrqHandler,

--- a/private/ntos/src/ex/sysinfo.c
+++ b/private/ntos/src/ex/sysinfo.c
@@ -42,6 +42,28 @@ QSI_DEF(SystemBasicInformation)
     return STATUS_SUCCESS;
 }
 
+/* Class 1 - Processor Information */
+QSI_DEF(SystemProcessorInformation)
+{
+    PSYSTEM_PROCESSOR_INFORMATION Spi = (PSYSTEM_PROCESSOR_INFORMATION) Buffer;
+
+    *ReqSize = sizeof(SYSTEM_PROCESSOR_INFORMATION);
+
+    /* Check user buffer's size */
+    if (Size != sizeof(SYSTEM_PROCESSOR_INFORMATION)) {
+	return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    RtlZeroMemory(Spi, Size);
+    Spi->ProcessorArchitecture = KeProcessorArchitecture;
+    Spi->ProcessorLevel = KeProcessorLevel;
+    Spi->ProcessorRevision = KeProcessorRevision;
+    Spi->MaximumProcessors = 0;
+    Spi->ProcessorFeatureBits = KeFeatureBits;
+    return STATUS_SUCCESS;
+}
+
+
 /* Class 3 - Time Of Day Information */
 QSI_DEF(SystemTimeOfDayInformation)
 {
@@ -98,7 +120,7 @@ typedef
 static
  QSSI_CALLS CallQS[] = {
     SI_QX(SystemBasicInformation),
-    NULL,    /* SI_QX(SystemProcessorInformation) */
+    SI_QX(SystemProcessorInformation),
     NULL,    /* SI_QX(SystemPerformanceInformation) */
     SI_QX(SystemTimeOfDayInformation),
     NULL,    /* SI_QX(SystemPathInformation) */


### PR DESCRIPTION
Hi

I wanted to have a first look around the code, and supposed implementing more QuerySystemInformation calls was a good start.
I added SystemProcessorInformation, which required adding a call to cpuid at the kernel startup.
If I find some time, I'll try to add others, it's fun.